### PR TITLE
fix: corrigir carregamento de imagens via WebSocket

### DIFF
--- a/frontend/components/ChatWindow.tsx
+++ b/frontend/components/ChatWindow.tsx
@@ -38,6 +38,7 @@ export default function ChatWindow({ receiverId, receiverName, receiverOnline: i
         receiverId: isFromCurrentUser ? receiverId : user?.id || 0,
         content: socketMessage.content,
         messageType: socketMessage.messageType,
+        media: socketMessage.media, // Include media data from WebSocket
         repliedMessageId: socketMessage.repliedMessageId,
         delivered: true,
         read: false,

--- a/frontend/components/MediaPreview.tsx
+++ b/frontend/components/MediaPreview.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useState } from 'react';
+import { Media } from '@/types';
+
+interface MediaPreviewProps {
+  media: Media;
+  isOwn: boolean;
+}
+
+export default function MediaPreview({ media, isOwn }: MediaPreviewProps) {
+  const [imageError, setImageError] = useState(false);
+  const [videoError, setVideoError] = useState(false);
+  const [showFullImage, setShowFullImage] = useState(false);
+
+  const formatFileSize = (bytes: number) => {
+    if (bytes === 0) return '0 Bytes';
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+  };
+
+  const formatDuration = (seconds: number) => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = Math.floor(seconds % 60);
+    return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
+  };
+
+  const getFileIcon = (fileType: string) => {
+    if (fileType.startsWith('image/')) {
+      return (
+        <svg className="w-8 h-8 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+      );
+    } else if (fileType.startsWith('video/')) {
+      return (
+        <svg className="w-8 h-8 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+        </svg>
+      );
+    } else if (fileType === 'application/pdf') {
+      return (
+        <svg className="w-8 h-8 text-red-600" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
+        </svg>
+      );
+    } else if (fileType.includes('word') || fileType.includes('document')) {
+      return (
+        <svg className="w-8 h-8 text-blue-600" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
+        </svg>
+      );
+    } else if (fileType.includes('excel') || fileType.includes('spreadsheet')) {
+      return (
+        <svg className="w-8 h-8 text-green-600" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
+        </svg>
+      );
+    } else {
+      return (
+        <svg className="w-8 h-8 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+      );
+    }
+  };
+
+  const renderImage = () => {
+    if (imageError) {
+      return (
+        <div className="flex items-center justify-center w-full h-32 bg-gray-100 rounded-lg">
+          <div className="text-center">
+            <svg className="w-8 h-8 text-gray-400 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            <p className="text-xs text-gray-500">Failed to load image</p>
+          </div>
+        </div>
+      );
+    }
+
+    const imageUrl = media.thumbnail || media.url;
+
+    return (
+      <div className="relative group cursor-pointer" onClick={() => setShowFullImage(true)}>
+        <img
+          src={imageUrl}
+          alt={media.fileName}
+          className="max-w-full h-auto rounded-lg shadow-sm hover:shadow-md transition-shadow"
+          style={{ maxHeight: '200px' }}
+          onError={() => setImageError(true)}
+        />
+        <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-200 rounded-lg flex items-center justify-center">
+          <svg className="w-6 h-6 text-white opacity-0 group-hover:opacity-100 transition-opacity" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7" />
+          </svg>
+        </div>
+      </div>
+    );
+  };
+
+  const renderVideo = () => {
+    if (videoError) {
+      return (
+        <div className="flex items-center justify-center w-full h-32 bg-gray-100 rounded-lg">
+          <div className="text-center">
+            <svg className="w-8 h-8 text-gray-400 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+            </svg>
+            <p className="text-xs text-gray-500">Failed to load video</p>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="relative">
+        <video
+          src={media.url}
+          className="max-w-full h-auto rounded-lg shadow-sm"
+          style={{ maxHeight: '200px' }}
+          controls
+          preload="metadata"
+          onError={() => setVideoError(true)}
+        />
+        {media.duration && (
+          <div className="absolute bottom-2 right-2 bg-black bg-opacity-75 text-white text-xs px-2 py-1 rounded">
+            {formatDuration(media.duration)}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const renderDocument = () => {
+    return (
+      <a
+        href={media.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 transition-colors"
+      >
+        {getFileIcon(media.fileType)}
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-gray-900 truncate">
+            {media.fileName}
+          </div>
+          <div className="text-xs text-gray-500">
+            {formatFileSize(media.fileSize)}
+          </div>
+        </div>
+        <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+        </svg>
+      </a>
+    );
+  };
+
+  const renderContent = () => {
+    if (media.fileType.startsWith('image/')) {
+      return renderImage();
+    } else if (media.fileType.startsWith('video/')) {
+      return renderVideo();
+    } else {
+      return renderDocument();
+    }
+  };
+
+  // Ensure we always render something when media is provided
+  if (!media || !media.url) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="mt-2">
+        {renderContent()}
+      </div>
+
+      {/* Full image modal */}
+      {showFullImage && media.fileType.startsWith('image/') && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50"
+          onClick={() => setShowFullImage(false)}
+        >
+          <div className="relative max-w-4xl max-h-full p-4">
+            <img
+              src={media.url}
+              alt={media.fileName}
+              className="max-w-full max-h-full object-contain"
+            />
+            <button
+              onClick={() => setShowFullImage(false)}
+              className="absolute top-4 right-4 text-white hover:text-gray-300"
+            >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+} 

--- a/frontend/components/MessageBubble.tsx
+++ b/frontend/components/MessageBubble.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import { Message } from '@/types';
 import { formatDistanceToNow } from 'date-fns';
 import { enUS } from 'date-fns/locale';
+import MediaPreview from './MediaPreview';
 
 interface MessageBubbleProps {
   message: Message;
@@ -110,7 +111,16 @@ export default function MessageBubble({ message, isOwn, onReply, repliedMessage 
           </div>
         )}
 
-        <p className="text-sm sm:text-base">{message.content}</p>
+        {/* Message content */}
+        {message.content && (
+          <p className="text-sm sm:text-base">{message.content}</p>
+        )}
+
+        {/* Media preview */}
+        {message.media && message.media.url && (
+          <MediaPreview media={message.media} isOwn={isOwn} />
+        )}
+
         <div className="flex items-center justify-between mt-1">
           <span className={`text-xs ${isOwn ? 'text-blue-100' : 'text-gray-500'}`}>
             {formatTime(message.createdAt)}


### PR DESCRIPTION
## Descrição

Corrige o bug onde imagens não apareciam imediatamente após serem enviadas via WebSocket, mas apareciam apenas após atualizar a página.

## Problema

Quando uma mensagem com imagem era enviada, os dados de mídia () não estavam sendo incluídos na nova mensagem recebida via WebSocket no frontend, causando a não exibição da imagem até que a página fosse atualizada.

## Solução

- **ChatWindow.tsx**: Adicionado  na criação da nova mensagem
- **MediaPreview.tsx**: Melhorada a renderização condicional e validação de dados
- **MessageBubble.tsx**: Adicionada verificação adicional para 

## Mudanças

- ✅ Imagens agora aparecem imediatamente após envio via WebSocket
- ✅ Melhor tratamento de erros na renderização de mídia
- ✅ Validação mais robusta dos dados de mídia

## Testes

- [x] Envio de imagem via chat
- [x] Verificação de exibição imediata
- [x] Teste de renderização em diferentes tipos de mídia

Closes #3